### PR TITLE
Bugfix/53 fixed black line on add child page

### DIFF
--- a/lib/app/pages/edit_child_page.dart
+++ b/lib/app/pages/edit_child_page.dart
@@ -171,11 +171,16 @@ class _EditChildPageState extends State<EditChildPage> {
         title: Text(widget.model == null ? 'New Child' : 'Edit Child'),
         centerTitle: true,
         actions: [
-          OutlinedButton(
-            onPressed: () async => await _submit(_imageFile),
-            child: Text(
-              'Save',
-              style: TextStyle(fontSize: 18, color: Colors.white),
+          GestureDetector(
+            onTap: () async => await _submit(_imageFile),
+            child: Align(
+              child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Text(
+                  'Save',
+                  style: TextStyle(fontSize: 18, color: Colors.white),
+                ),
+              ),
             ),
           )
         ],


### PR DESCRIPTION
Removed black line in the appbar before save text in the add child screen.
<img src="https://github.com/JordyHers-org/Times-up-flutter/assets/112814295/c71812c0-9555-452e-8f49-0d15be5a7047" width="200" height="50">
<img src="https://github.com/JordyHers-org/Times-up-flutter/assets/112814295/e6a61b7c-3aa0-4a5a-ae09-b43f9af299bd" width="200" height="444">