### PR TITLE
chore: Removed `flutter_sdk` which is used as a symlink to the flutte…

### DIFF
--- a/.fvm/flutter_sdk
+++ b/.fvm/flutter_sdk
@@ -1,1 +1,0 @@
-/Users/jordyigondjo/fvm/versions/3.10.0

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@
    ```
 
 2. **Install Flutter Version**
-   Install FVM via Homebrew and use Flutter version 3.7.12.
+   Open the Command Prompt as Administrator. Install FVM via Homebrew and use Flutter via FVM. The required Flutter version will be installed.
    ```bash
    
    brew install fvm
-   fvm install 3.7.12
+   fvm flutter pub get
    ```
 
 3. **Request Firebase Options File**
@@ -34,7 +34,7 @@
 
    ```
 
-3. **Extra** <br/>
+4. **Extra** <br/>
    For child's pictures feel free to use any of the pictures available.
    
 


### PR DESCRIPTION
Changes made:
- Removed `flutter_sdk` from the repo which is used as a symlink to the flutter folder. This file was causing error when running `fvm flutter clean` as that file already exists.
- Updated readme so that the appropriate flutter version is downloaded based on fvm configured in `fvm_config.json`. Also it is required to run the terminal/command prompt as Administrator because fvm needs to create that symlink file.

![image](https://github.com/JordyHers-org/Times-up-flutter/assets/5429312/161339bd-df5d-408b-965a-af3f9cd622b5)

![image](https://github.com/JordyHers-org/Times-up-flutter/assets/5429312/140d9d29-2ac4-4a0f-93b5-188f8a22cb8f)


