### PR TITLE
chore(#124) : replace all Padding occurrences with padding extension

### DIFF
--- a/lib/app/pages/child_details_page.dart
+++ b/lib/app/pages/child_details_page.dart
@@ -12,6 +12,7 @@ import 'package:parental_control/common_widgets/show_exeption_alert.dart';
 import 'package:parental_control/models/child_model.dart';
 import 'package:parental_control/models/notification_model.dart';
 import 'package:parental_control/services/database.dart';
+import 'package:parental_control/theme/theme.dart';
 import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
 
@@ -182,107 +183,95 @@ class _ChildDetailsPageState extends State<ChildDetailsPage> {
               ),
             ),
             SizedBox(height: 8),
-            Padding(
-              padding: const EdgeInsets.only(left: 50.0),
-              child: RichText(
-                text: TextSpan(
-                  text: "Send notifications to your Child's device",
-                  style: TextStyle(color: Colors.indigo, fontSize: 14),
-                ),
+            RichText(
+              text: TextSpan(
+                text: "Send notifications to your Child's device",
+                style: TextStyle(color: Colors.indigo, fontSize: 14),
               ),
-            ),
+            ).cP(l: 50),
             SizedBox(height: 2),
-            Padding(
-              padding: const EdgeInsets.only(left: 50.0),
-              child: RichText(
-                text: TextSpan(
-                  text: 'Push the button ',
-                  style: TextStyle(color: Colors.grey, fontSize: 11),
-                ),
+            RichText(
+              text: TextSpan(
+                text: 'Push the button ',
+                style: TextStyle(color: Colors.grey, fontSize: 11),
               ),
-            ),
+            ).cP(l: 50),
             SizedBox(height: 8),
             Container(
               decoration: BoxDecoration(color: Colors.white),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(75.0, 22, 75, 12),
-                    child: CustomRaisedButton(
-                      child: Text(
-                        ' Bed Time',
-                        style: TextStyle(fontSize: 17, color: Colors.white),
-                      ),
-                      borderRadius: 12,
-                      color: Colors.indigo,
-                      height: 45,
-                      onPressed: () async {
-                        try {
-                          await widget.database.setNotification(
-                            NotificationModel(
-                              id: model.id,
-                              title: ' Hey ${model.name}',
-                              body: 'Here is a new message',
-                              message: 'Go to bed now ',
-                            ),
-                            model,
-                          );
-                          await showAlertDialog(
-                            context,
-                            title: 'Successful',
-                            content: 'Notification sent to ${model.name}',
-                            defaultActionText: 'OK',
-                          );
-                          debugPrint('Notification sent to device');
-                        } on FirebaseException catch (e) {
-                          await showExceptionAlertDialog(
-                            context,
-                            title: 'An error occurred',
-                            exception: e,
-                          );
-                        }
-                      },
+                  CustomRaisedButton(
+                    child: Text(
+                      ' Bed Time',
+                      style: TextStyle(fontSize: 17, color: Colors.white),
                     ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(75.0, 12, 75, 6),
-                    child: CustomRaisedButton(
-                      child: Text(
-                        'Homework Time',
-                        style: TextStyle(fontSize: 17),
-                      ),
-                      borderRadius: 12,
-                      color: Colors.white,
-                      height: 45,
-                      onPressed: () async {
-                        try {
-                          await widget.database.setNotification(
-                            NotificationModel(
-                              id: model.id,
-                              title: ' Hey ${model.name}',
-                              body: 'Here is a new message',
-                              message: 'Homework Time',
-                            ),
-                            model,
-                          );
-                          await showAlertDialog(
-                            context,
-                            title: 'Successful',
-                            content: 'Notification sent to ${model.name}',
-                            defaultActionText: 'OK',
-                          );
-                          debugPrint('Notification sent to device');
-                        } on FirebaseException catch (e) {
-                          await showExceptionAlertDialog(
-                            context,
-                            title: 'An error occurred',
-                            exception: e,
-                          );
-                        }
-                      },
+                    borderRadius: 12,
+                    color: Colors.indigo,
+                    height: 45,
+                    onPressed: () async {
+                      try {
+                        await widget.database.setNotification(
+                          NotificationModel(
+                            id: model.id,
+                            title: ' Hey ${model.name}',
+                            body: 'Here is a new message',
+                            message: 'Go to bed now ',
+                          ),
+                          model,
+                        );
+                        await showAlertDialog(
+                          context,
+                          title: 'Successful',
+                          content: 'Notification sent to ${model.name}',
+                          defaultActionText: 'OK',
+                        );
+                        debugPrint('Notification sent to device');
+                      } on FirebaseException catch (e) {
+                        await showExceptionAlertDialog(
+                          context,
+                          title: 'An error occurred',
+                          exception: e,
+                        );
+                      }
+                    },
+                  ).cP(l: 75, t: 22, r: 75, b:12),
+                  CustomRaisedButton(
+                    child: Text(
+                      'Homework Time',
+                      style: TextStyle(fontSize: 17),
                     ),
-                  ),
+                    borderRadius: 12,
+                    color: Colors.white,
+                    height: 45,
+                    onPressed: () async {
+                      try {
+                        await widget.database.setNotification(
+                          NotificationModel(
+                            id: model.id,
+                            title: ' Hey ${model.name}',
+                            body: 'Here is a new message',
+                            message: 'Homework Time',
+                          ),
+                          model,
+                        );
+                        await showAlertDialog(
+                          context,
+                          title: 'Successful',
+                          content: 'Notification sent to ${model.name}',
+                          defaultActionText: 'OK',
+                        );
+                        debugPrint('Notification sent to device');
+                      } on FirebaseException catch (e) {
+                        await showExceptionAlertDialog(
+                          context,
+                          title: 'An error occurred',
+                          exception: e,
+                        );
+                      }
+                    },
+                  ).cP(l: 75, t: 12, r: 75, b:6),
                 ],
               ),
               height: 150,

--- a/lib/app/pages/child_page.dart
+++ b/lib/app/pages/child_page.dart
@@ -9,6 +9,7 @@ import 'package:parental_control/models/child_model.dart';
 import 'package:parental_control/models/notification_model.dart';
 import 'package:parental_control/services/app_usage_service.dart';
 import 'package:parental_control/services/database.dart';
+import 'package:parental_control/theme/theme.dart';
 import 'package:provider/provider.dart';
 
 class ChildPage extends StatefulWidget {
@@ -71,45 +72,42 @@ class _ChildPageState extends State<ChildPage> {
                     height: 250,
                     color: Colors.indigo,
                     child: DrawerHeader(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            SizedBox(height: 6),
-                            CircleAvatar(
-                              backgroundImage:
-                                  NetworkImage(widget.child!.image!),
-                              radius: 45,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          SizedBox(height: 6),
+                          CircleAvatar(
+                            backgroundImage:
+                                NetworkImage(widget.child!.image!),
+                            radius: 45,
+                          ),
+                          SizedBox(height: 6),
+                          Text(
+                            '${widget.child!.name} ',
+                            style: TextStyle(
+                              fontSize: 19,
+                              fontWeight: FontWeight.w800,
                             ),
-                            SizedBox(height: 6),
-                            Text(
-                              '${widget.child!.name} ',
-                              style: TextStyle(
-                                fontSize: 19,
-                                fontWeight: FontWeight.w800,
-                              ),
+                          ),
+                          SizedBox(height: 12),
+                          Text(
+                            '${widget.child!.email} ',
+                            style: TextStyle(
+                              fontSize: 15,
+                              fontWeight: FontWeight.w800,
                             ),
-                            SizedBox(height: 12),
-                            Text(
-                              '${widget.child!.email} ',
-                              style: TextStyle(
-                                fontSize: 15,
-                                fontWeight: FontWeight.w800,
-                              ),
+                          ),
+                          SizedBox(height: 6),
+                          Text(
+                            '${widget.child!.id} ',
+                            style: TextStyle(
+                              fontSize: 15,
+                              fontWeight: FontWeight.w800,
                             ),
-                            SizedBox(height: 6),
-                            Text(
-                              '${widget.child!.id} ',
-                              style: TextStyle(
-                                fontSize: 15,
-                                fontWeight: FontWeight.w800,
-                              ),
-                            ),
-                            SizedBox(height: 6),
-                          ],
-                        ),
-                      ),
+                          ),
+                          SizedBox(height: 6),
+                        ],
+                      ).hP8,
                     ),
                   )
                 : Container(),
@@ -219,20 +217,17 @@ class _ChildPageState extends State<ChildPage> {
             itemBuilder: (context, index) {
               return Card(
                 color: Colors.indigo,
-                child: Padding(
-                  padding: EdgeInsets.all(8.0),
-                  child: ListTile(
-                    title: Text(data[index].title ?? 'No title available'),
-                    trailing: Text(
-                      data[index].message ?? 'No message available',
-                      style: TextStyle(
-                        fontWeight: FontWeight.w600,
-                        color: Colors.white,
-                        fontSize: 16,
-                      ),
+                child: ListTile(
+                  title: Text(data[index].title ?? 'No title available'),
+                  trailing: Text(
+                    data[index].message ?? 'No message available',
+                    style: TextStyle(
+                      fontWeight: FontWeight.w600,
+                      color: Colors.white,
+                      fontSize: 16,
                     ),
                   ),
-                ),
+                ).p8,
               );
             },
           );

--- a/lib/app/pages/edit_child_page.dart
+++ b/lib/app/pages/edit_child_page.dart
@@ -7,6 +7,7 @@ import 'package:parental_control/common_widgets/show_alert_dialog.dart';
 import 'package:parental_control/common_widgets/show_exeption_alert.dart';
 import 'package:parental_control/models/child_model.dart';
 import 'package:parental_control/services/database.dart';
+import 'package:parental_control/theme/theme.dart';
 import 'package:path/path.dart' as path;
 import 'package:uuid/uuid.dart';
 
@@ -174,13 +175,10 @@ class _EditChildPageState extends State<EditChildPage> {
           GestureDetector(
             onTap: () async => await _submit(_imageFile),
             child: Align(
-              child: Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: Text(
-                  'Save',
-                  style: TextStyle(fontSize: 18, color: Colors.white),
-                ),
-              ),
+              child: Text(
+                'Save',
+                style: TextStyle(fontSize: 18, color: Colors.white),
+              ).p8,
             ),
           )
         ],
@@ -192,15 +190,9 @@ class _EditChildPageState extends State<EditChildPage> {
   Widget _buildContents() {
     return !isSavedPressed
         ? SingleChildScrollView(
-            child: Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: Card(
-                child: Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: _buildForm(),
-                ),
-              ),
-            ),
+            child: Card(
+              child: _buildForm().p16,
+            ).p16,
           )
         : Center(child: CircularProgressIndicator());
   }
@@ -217,40 +209,37 @@ class _EditChildPageState extends State<EditChildPage> {
 
   List<Widget> _buildFormChildren() {
     return [
-      Padding(
-        padding: const EdgeInsets.all(8.0),
-        child: Column(
-          children: [
-            SizedBox(height: 8),
-            appState == AppState.complete
-                ? _showImage()
-                : Container(
-                    height: 90,
-                    color: Colors.black.withOpacity(0.14),
-                    child: Center(child: CircularProgressIndicator()),
-                  ),
-            ButtonTheme(
-              child: ElevatedButton(
-                style: ButtonStyle(
-                  shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                    RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(10.0),
-                    ),
-                  ),
-                  backgroundColor: MaterialStateProperty.all<Color>(
-                    Theme.of(context).primaryColor,
+      Column(
+        children: [
+          SizedBox(height: 8),
+          appState == AppState.complete
+              ? _showImage()
+              : Container(
+                  height: 90,
+                  color: Colors.black.withOpacity(0.14),
+                  child: Center(child: CircularProgressIndicator()),
+                ),
+          ButtonTheme(
+            child: ElevatedButton(
+              style: ButtonStyle(
+                shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+                  RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10.0),
                   ),
                 ),
-                onPressed: () => _getLocalImage(),
-                child: Text(
-                  'add picture',
-                  style: TextStyle(color: Colors.white),
+                backgroundColor: MaterialStateProperty.all<Color>(
+                  Theme.of(context).primaryColor,
                 ),
               ),
-            )
-          ],
-        ),
-      ),
+              onPressed: () => _getLocalImage(),
+              child: Text(
+                'add picture',
+                style: TextStyle(color: Colors.white),
+              ),
+            ),
+          )
+        ],
+      ).p8,
       TextFormField(
         decoration: InputDecoration(labelText: 'Child name'),
         initialValue: _name,

--- a/lib/app/pages/notification_page.dart
+++ b/lib/app/pages/notification_page.dart
@@ -83,19 +83,16 @@ class _NotificationPageState extends State<NotificationPage> {
                     return Dismissible(
                       background: Card(
                         color: Colors.red,
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.end,
-                            children: [
-                              Icon(
-                                Icons.delete_forever,
-                                color: Colors.white,
-                                size: 25,
-                              )
-                            ],
-                          ),
-                        ),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.end,
+                          children: [
+                            Icon(
+                              Icons.delete_forever,
+                              color: Colors.white,
+                              size: 25,
+                            )
+                          ],
+                        ).hP8,
                       ),
                       key: ValueKey<int>(index),
                       onDismissed: (DismissDirection direction) async {
@@ -111,22 +108,19 @@ class _NotificationPageState extends State<NotificationPage> {
                       direction: DismissDirection.endToStart,
                       child: Card(
                         color: CustomColors.indigoLight,
-                        child: Padding(
-                          padding: EdgeInsets.all(8.0),
-                          child: ListTile(
-                            title: Text(
-                              data[index].title ?? 'No title available',
-                            ),
-                            trailing: Text(
-                              data[index].message ?? 'No message available',
-                              style: TextStyle(
-                                fontWeight: FontWeight.w600,
-                                color: Colors.white,
-                                fontSize: 16,
-                              ),
+                        child: ListTile(
+                          title: Text(
+                            data[index].title ?? 'No title available',
+                          ),
+                          trailing: Text(
+                            data[index].message ?? 'No message available',
+                            style: TextStyle(
+                              fontWeight: FontWeight.w600,
+                              color: Colors.white,
+                              fontSize: 16,
                             ),
                           ),
-                        ),
+                        ).p8,
                       ),
                     );
                   },

--- a/lib/app/pages/parent_page.dart
+++ b/lib/app/pages/parent_page.dart
@@ -207,7 +207,7 @@ class _ParentPageState extends State<ParentPage>
                               Icons.info_outline_rounded,
                               color: Colors.deepOrangeAccent.shade100,
                             ),
-                          ).p8,
+                          ).tP8,
                           SizedBox(height: 3),
                           _buildChildrenList(database),
                           _header(),
@@ -314,13 +314,10 @@ class _ParentPageState extends State<ParentPage>
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Padding(
-          padding: EdgeInsets.only(top: 20.0),
-          child: Text(
-            "Follow your child's location ",
-            style: TextStyle(color: CustomColors.indigoLight),
-          ),
-        ),
+        Text(
+          "Follow your child's location ",
+          style: TextStyle(color: CustomColors.indigoLight),
+        ).cP(t: 20),
         Text(
           'Long Press the map to open the full screen mode',
           style: TextStyle(color: CustomColors.greenPrimary),

--- a/lib/app/pages/set_child_page.dart
+++ b/lib/app/pages/set_child_page.dart
@@ -6,6 +6,7 @@ import 'package:parental_control/common_widgets/show_alert_dialog.dart';
 import 'package:parental_control/models/set_child_model.dart';
 import 'package:parental_control/services/database.dart';
 import 'package:parental_control/services/geo_locator_service.dart';
+import 'package:parental_control/theme/theme.dart';
 import 'package:provider/provider.dart';
 
 enum AppState { loading, complete }
@@ -127,19 +128,13 @@ class _SetChildPageState extends State<SetChildPage> {
         centerTitle: true,
       ),
       body: SingleChildScrollView(
-        child: Padding(
-          padding: const EdgeInsets.all(16.0),
-          child: Card(
-            child: Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                mainAxisSize: MainAxisSize.max,
-                children: _buildChildren(context),
-              ),
-            ),
-          ),
-        ),
+        child: Card(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            mainAxisSize: MainAxisSize.max,
+            children: _buildChildren(context),
+          ).p16,
+        ).p16,
       ),
     );
   }

--- a/lib/app/pages/setting_page.dart
+++ b/lib/app/pages/setting_page.dart
@@ -98,25 +98,22 @@ class SettingsPage extends StatelessWidget {
       ),
       body: Stack(
         children: <Widget>[
-          Padding(
-            padding: const EdgeInsets.only(top: 18.0, left: 8, bottom: 8),
-            child: Column(
-              mainAxisSize: MainAxisSize.max,
-              children: <Widget>[
-                buildItems(context),
-                ListTile(
-                  leading: IconButton(
-                    icon: Icon(Icons.contact_support_sharp),
-                    onPressed: () {},
-                  ),
-                  trailing: Text(
-                    'Developed by Jordy-Hershel',
-                    style: TextStyle(color: Colors.redAccent, fontSize: 12),
-                  ),
-                )
-              ],
-            ),
-          )
+          Column(
+            mainAxisSize: MainAxisSize.max,
+            children: <Widget>[
+              buildItems(context),
+              ListTile(
+                leading: IconButton(
+                  icon: Icon(Icons.contact_support_sharp),
+                  onPressed: () {},
+                ),
+                trailing: Text(
+                  'Developed by Jordy-Hershel',
+                  style: TextStyle(color: Colors.redAccent, fontSize: 12),
+                ),
+              )
+            ],
+          ).cP(l: 8, t: 18, b: 8)
         ],
       ),
     );

--- a/lib/app/splash/splash_content.dart
+++ b/lib/app/splash/splash_content.dart
@@ -17,36 +17,31 @@ class SplashContent extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.spaceAround,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
-        Padding(
-          padding: const EdgeInsets.symmetric(
-            horizontal: 10.0,
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              DisplayText(
-                text: "Time's Up",
-                fontSize: 35,
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            DisplayText(
+              text: "Time's Up",
+              fontSize: 35,
+              style: TextStyle(
+                color: CustomColors.indigoDark,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            SizedBox(height: 8),
+            Container(
+              width: MediaQuery.of(context).size.width / 1.5,
+              child: DisplayText(
+                text: text,
                 style: TextStyle(
-                  color: CustomColors.indigoDark,
-                  fontWeight: FontWeight.w800,
+                  color: Colors.black.withOpacity(0.5),
+                  fontWeight: FontWeight.w500,
+                  height: 1.5,
                 ),
               ),
-              SizedBox(height: 8),
-              Container(
-                width: MediaQuery.of(context).size.width / 1.5,
-                child: DisplayText(
-                  text: text,
-                  style: TextStyle(
-                    color: Colors.black.withOpacity(0.5),
-                    fontWeight: FontWeight.w500,
-                    height: 1.5,
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
+            ),
+          ],
+        ).hP(10),
         Image.asset(
           image,
           height: getProportionateScreenHeight(150),

--- a/lib/app/splash/splash_screen.dart
+++ b/lib/app/splash/splash_screen.dart
@@ -73,93 +73,88 @@ class _SplashScreenState extends State<SplashScreen> {
               ),
               Expanded(
                 flex: 1,
-                child: Padding(
-                  padding: EdgeInsets.symmetric(
-                    horizontal: getProportionateScreenWidth(20),
-                  ),
-                  child: Column(
-                    children: <Widget>[
-                      Spacer(flex: 3),
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                        children: [
-                          Container(
-                            height: 40,
-                            child: ElevatedButton(
-                              style: ButtonStyle(
-                                backgroundColor:
-                                    MaterialStateProperty.all<Color>(
-                                  Theme.of(context).primaryColor,
-                                ),
+                child: Column(
+                  children: <Widget>[
+                    Spacer(flex: 3),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                      children: [
+                        Container(
+                          height: 40,
+                          child: ElevatedButton(
+                            style: ButtonStyle(
+                              backgroundColor:
+                                  MaterialStateProperty.all<Color>(
+                                Theme.of(context).primaryColor,
                               ),
-                              onPressed: () {
-                                SharedPreference().setVisitingFlag();
-                                SharedPreference().setParentDevice();
-                                debugPrint(
-                                  'The page is set to Parent => now moving ..',
-                                );
-                                Navigator.of(context).pushReplacement(
-                                  CupertinoPageRoute(
-                                    builder: (context) => LandingPage(),
-                                  ),
-                                );
-                              },
-                              child: Text(
-                                'Parent device'.toUpperCase(),
-                                style: TextStyle(
-                                  fontSize: getProportionateScreenWidth(10),
-                                  color: Colors.white,
+                            ),
+                            onPressed: () {
+                              SharedPreference().setVisitingFlag();
+                              SharedPreference().setParentDevice();
+                              debugPrint(
+                                'The page is set to Parent => now moving ..',
+                              );
+                              Navigator.of(context).pushReplacement(
+                                CupertinoPageRoute(
+                                  builder: (context) => LandingPage(),
                                 ),
+                              );
+                            },
+                            child: Text(
+                              'Parent device'.toUpperCase(),
+                              style: TextStyle(
+                                fontSize: getProportionateScreenWidth(10),
+                                color: Colors.white,
                               ),
                             ),
                           ),
-
-                          ///------------------------------------
-                          Container(
-                            height: 40,
-                            child: ElevatedButton(
-                              style: ButtonStyle(
-                                backgroundColor:
-                                    MaterialStateProperty.all<Color>(
-                                  CustomColors.greenPrimary,
-                                ),
-                              ),
-                              onPressed: () {
-                                SharedPreference().setVisitingFlag();
-                                SharedPreference().setChildDevice();
-
-                                debugPrint(
-                                  'The page is set to Child => now moving ....',
-                                );
-                                Navigator.of(context).pushReplacement(
-                                  CupertinoPageRoute(
-                                    builder: (context) => LandingPage(),
-                                  ),
-                                );
-                              },
-                              child: Text(
-                                ' Child device'.toUpperCase(),
-                                style: TextStyle(
-                                  fontSize: getProportionateScreenWidth(10),
-                                  color: Colors.white,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                      Spacer(flex: 1),
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: List.generate(
-                          splashData.length,
-                          (index) => buildDot(index: index),
                         ),
+
+                        ///------------------------------------
+                        Container(
+                          height: 40,
+                          child: ElevatedButton(
+                            style: ButtonStyle(
+                              backgroundColor:
+                                  MaterialStateProperty.all<Color>(
+                                CustomColors.greenPrimary,
+                              ),
+                            ),
+                            onPressed: () {
+                              SharedPreference().setVisitingFlag();
+                              SharedPreference().setChildDevice();
+
+                              debugPrint(
+                                'The page is set to Child => now moving ....',
+                              );
+                              Navigator.of(context).pushReplacement(
+                                CupertinoPageRoute(
+                                  builder: (context) => LandingPage(),
+                                ),
+                              );
+                            },
+                            child: Text(
+                              ' Child device'.toUpperCase(),
+                              style: TextStyle(
+                                fontSize: getProportionateScreenWidth(10),
+                                color: Colors.white,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    Spacer(flex: 1),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: List.generate(
+                        splashData.length,
+                        (index) => buildDot(index: index),
                       ),
-                      Spacer(),
-                    ],
-                  ),
-                ),
+                    ),
+                    Spacer(),
+                  ],
+                ).hP(getProportionateScreenWidth(20)),
               ),
             ],
           ),

--- a/lib/common_widgets/bar_chart.dart
+++ b/lib/common_widgets/bar_chart.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:parental_control/theme/theme.dart';
 
 class AppUsageChart extends StatefulWidget {
   final List<Color> availableColors = const [
@@ -40,70 +41,61 @@ class AppUsageChartState extends State<AppUsageChart> {
         color: Theme.of(context).primaryColor,
         child: Stack(
           children: <Widget>[
-            Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                mainAxisAlignment: MainAxisAlignment.start,
-                mainAxisSize: MainAxisSize.max,
-                children: <Widget>[
-                  Text(
-                    widget.name,
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: 15,
-                      fontWeight: FontWeight.bold,
-                    ),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              mainAxisAlignment: MainAxisAlignment.start,
+              mainAxisSize: MainAxisSize.max,
+              children: <Widget>[
+                Text(
+                  widget.name,
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 15,
+                    fontWeight: FontWeight.bold,
                   ),
-                  const SizedBox(
-                    height: 4,
-                  ),
-                  const Text(
-                    'App Usage Graph',
-                    style: TextStyle(
-                      color: Color(0xff379982),
-                      fontSize: 12,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  const SizedBox(
-                    height: 18,
-                  ),
-                  Expanded(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                      child: BarChart(
-                        isPlaying ? randomData() : mainBarData(),
-                        swapAnimationDuration: animDuration,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(
-                    height: 6,
-                  ),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.all(4.0),
-              child: Align(
-                alignment: Alignment.topRight,
-                child: IconButton(
-                  icon: Icon(
-                    isPlaying ? Icons.pause : Icons.play_arrow,
-                    color: Colors.pinkAccent,
-                  ),
-                  onPressed: () {
-                    setState(() {
-                      isPlaying = !isPlaying;
-                      if (isPlaying) {
-                        refreshState();
-                      }
-                    });
-                  },
                 ),
+                const SizedBox(
+                  height: 4,
+                ),
+                const Text(
+                  'App Usage Graph',
+                  style: TextStyle(
+                    color: Color(0xff379982),
+                    fontSize: 12,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(
+                  height: 18,
+                ),
+                Expanded(
+                  child: BarChart(
+                    isPlaying ? randomData() : mainBarData(),
+                    swapAnimationDuration: animDuration,
+                  ).hP8,
+                ),
+                const SizedBox(
+                  height: 6,
+                ),
+              ],
+            ).p16,
+            Align(
+              alignment: Alignment.topRight,
+              child: IconButton(
+                icon: Icon(
+                  isPlaying ? Icons.pause : Icons.play_arrow,
+                  color: Colors.pinkAccent,
+                ),
+                onPressed: () {
+                  setState(() {
+                    isPlaying = !isPlaying;
+                    if (isPlaying) {
+                      refreshState();
+                    }
+                  });
+                },
               ),
-            )
+            ).p4
           ],
         ),
       ),
@@ -314,7 +306,7 @@ class AppUsageChartState extends State<AppUsageChart> {
         text = const Text('', style: style);
         break;
     }
-    return Padding(padding: const EdgeInsets.only(top: 16), child: text);
+    return text.tP16;
   }
 
   BarChartData randomData() {

--- a/lib/sign_in/email_sign_in_form_bloc_based.dart
+++ b/lib/sign_in/email_sign_in_form_bloc_based.dart
@@ -199,14 +199,11 @@ class _EmailSignInFormBlocBasedState extends State<EmailSignInFormBlocBased> {
         builder: (context, snapshot) {
           final model = snapshot.data;
 
-          return Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              mainAxisSize: MainAxisSize.min,
-              children: _buildChildren(model!),
-            ),
-          );
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            mainAxisSize: MainAxisSize.min,
+            children: _buildChildren(model!),
+          ).p16;
         },
       ),
     );

--- a/lib/sign_in/email_sign_in_page.dart
+++ b/lib/sign_in/email_sign_in_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:parental_control/sign_in/email_sign_in_form_bloc_based.dart';
+import 'package:parental_control/theme/theme.dart';
 
 class EmailSignInPage extends StatelessWidget {
   @override
@@ -12,18 +13,15 @@ class EmailSignInPage extends StatelessWidget {
         centerTitle: true,
       ),
       body: SingleChildScrollView(
-        child: Padding(
-          padding: const EdgeInsets.all(16.0),
-          child: Card(
-            /// Here we can change the child to
-            ///
-            /// EmailSignInFormChangeNotifier.create(context)
-            /// EmailSignInFormBlocBased.create(context)
-            /// EmailSignInFormStateful.create(context)
-            /// According to your preferences
-            child: EmailSignInFormBlocBased.create(context),
-          ),
-        ),
+        child: Card(
+          /// Here we can change the child to
+          ///
+          /// EmailSignInFormChangeNotifier.create(context)
+          /// EmailSignInFormBlocBased.create(context)
+          /// EmailSignInFormStateful.create(context)
+          /// According to your preferences
+          child: EmailSignInFormBlocBased.create(context),
+        ).p16,
       ),
     );
   }

--- a/lib/sign_in/phone_sign_bloc_based.dart
+++ b/lib/sign_in/phone_sign_bloc_based.dart
@@ -2,6 +2,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:parental_control/app/pages/parent_page.dart';
 import 'package:parental_control/common_widgets/form_submit_button.dart';
+import 'package:parental_control/theme/theme.dart';
 
 class PhoneSignInFormBlocBased extends StatefulWidget {
   PhoneSignInFormBlocBased({Key? key}) : super(key: key);
@@ -154,14 +155,11 @@ class _PhoneSignInFormBlocBasedState extends State<PhoneSignInFormBlocBased> {
   @override
   Widget build(BuildContext context) {
     return SingleChildScrollView(
-      child: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          mainAxisSize: MainAxisSize.min,
-          children: _buildChildren(context),
-        ),
-      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
+        children: _buildChildren(context),
+      ).p16,
     );
   }
 }

--- a/lib/sign_in/phone_sign_in.dart
+++ b/lib/sign_in/phone_sign_in.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:parental_control/sign_in/phone_sign_bloc_based.dart';
+import 'package:parental_control/theme/theme.dart';
 
 class PhoneSignInPage extends StatelessWidget {
   @override
@@ -12,12 +13,9 @@ class PhoneSignInPage extends StatelessWidget {
         centerTitle: true,
       ),
       body: SingleChildScrollView(
-        child: Padding(
-          padding: const EdgeInsets.all(16.0),
-          child: Card(
-            child: PhoneSignInFormBlocBased(),
-          ),
-        ),
+        child: Card(
+          child: PhoneSignInFormBlocBased(),
+        ).p16,
       ),
     );
   }

--- a/lib/sign_in/sign_in_page.dart
+++ b/lib/sign_in/sign_in_page.dart
@@ -99,42 +99,39 @@ class SignInPage extends StatelessWidget {
   Widget _buildContent(BuildContext context) {
     return Container(
       decoration: BoxDecoration(color: CustomColors.indigoLight),
-      child: Padding(
-        padding: EdgeInsets.all(16.0),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: <Widget>[
-            SizedBox(height: 180.0, child: _buildHeader()),
-            SizedBox(height: 28.0),
-            SocialSignInButton(
-              assetName: 'images/google-logo.png',
-              text: 'Sign in With Google',
-              textColor: Colors.black87,
-              color: Colors.white,
-              onPressed: () => isLoading ? null : _signInWithGoogle(context),
-            ),
-            SizedBox(height: 8.0),
-            SocialSignInButton(
-              assetName: 'images/facebook-logo.png',
-              text: 'Sign in With Facebook',
-              textColor: Colors.white,
-              color: Color(0xFF334D92),
-              onPressed: () => isLoading ? null : _signInWithFacebook(context),
-            ),
-            SizedBox(height: 8.0),
-            SignInButton(
-              key: Keys.emailKeys,
-              text: 'Sign in With email',
-              textColor: Colors.white,
-              color: Colors.teal[700],
-              onPressed: () => isLoading ? null : _signInWithEmail(context),
-            ),
-            SizedBox(height: 8.0),
-            SizedBox(height: 8.0),
-          ],
-        ),
-      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          SizedBox(height: 180.0, child: _buildHeader()),
+          SizedBox(height: 28.0),
+          SocialSignInButton(
+            assetName: 'images/google-logo.png',
+            text: 'Sign in With Google',
+            textColor: Colors.black87,
+            color: Colors.white,
+            onPressed: () => isLoading ? null : _signInWithGoogle(context),
+          ),
+          SizedBox(height: 8.0),
+          SocialSignInButton(
+            assetName: 'images/facebook-logo.png',
+            text: 'Sign in With Facebook',
+            textColor: Colors.white,
+            color: Color(0xFF334D92),
+            onPressed: () => isLoading ? null : _signInWithFacebook(context),
+          ),
+          SizedBox(height: 8.0),
+          SignInButton(
+            key: Keys.emailKeys,
+            text: 'Sign in With email',
+            textColor: Colors.white,
+            color: Colors.teal[700],
+            onPressed: () => isLoading ? null : _signInWithEmail(context),
+          ),
+          SizedBox(height: 8.0),
+          SizedBox(height: 8.0),
+        ],
+      ).p16,
     );
   }
 

--- a/lib/theme/theme.dart
+++ b/lib/theme/theme.dart
@@ -62,29 +62,63 @@ class AppTheme {
 }
 
 extension PaddingHelper on Widget {
-  Padding get p16 => Padding(padding: EdgeInsets.all(16), child: this);
-  Padding get p8 => Padding(padding: EdgeInsets.only(top: 8), child: this);
-  Padding get p4 => Padding(padding: EdgeInsets.all(8), child: this);
+  Padding get p4 => Padding(padding: const EdgeInsets.all(4), child: this);
+  Padding get p8 => Padding(padding: const EdgeInsets.all(8), child: this);
+  Padding get p16 => Padding(padding: const EdgeInsets.all(16), child: this);
 
   /// Set padding according to `value`
   Padding p(double value) =>
       Padding(padding: EdgeInsets.all(value), child: this);
 
+  /// Symetric Padding
+  Padding sP(double horizontal, double vertical) => Padding(
+    padding: EdgeInsets.symmetric(
+      horizontal: horizontal,
+      vertical: vertical,
+    ),
+    child: this,
+  );
+
   /// Horizontal Padding 16
   Padding get hP4 =>
-      Padding(padding: EdgeInsets.symmetric(horizontal: 4), child: this);
+      Padding(padding: const EdgeInsets.symmetric(horizontal: 4), child: this);
   Padding get hP8 =>
-      Padding(padding: EdgeInsets.symmetric(horizontal: 8), child: this);
+      Padding(padding: const EdgeInsets.symmetric(horizontal: 8), child: this);
   Padding get hP16 =>
-      Padding(padding: EdgeInsets.symmetric(horizontal: 16), child: this);
+      Padding(padding: const EdgeInsets.symmetric(horizontal: 16), child: this);
+  Padding hP(double value) =>
+      Padding(padding: EdgeInsets.symmetric(horizontal: value), child: this);
 
   /// Vertical Padding 16
   Padding get vP16 =>
-      Padding(padding: EdgeInsets.symmetric(vertical: 16), child: this);
+      Padding(padding: const EdgeInsets.symmetric(vertical: 16), child: this);
   Padding get vP8 =>
-      Padding(padding: EdgeInsets.symmetric(vertical: 8), child: this);
+      Padding(padding: const EdgeInsets.symmetric(vertical: 8), child: this);
   Padding get vP4 =>
-      Padding(padding: EdgeInsets.symmetric(vertical: 8), child: this);
+      Padding(padding: const EdgeInsets.symmetric(vertical: 4), child: this);
+
+  // Padding only (Top)
+  Padding get tP8 =>
+      Padding(padding: const EdgeInsets.only(top: 8), child: this);
+  Padding get tP16 =>
+      Padding(padding: const EdgeInsets.only(top: 16), child: this);
+
+  /// Padding all custom
+  Padding cP({
+    double t = 0.0,
+    double b = 0.0,
+    double l = 0.0,
+    double r = 0.0,
+  }) =>
+      Padding(
+        padding: EdgeInsets.only(
+          left: l,
+          right: r,
+          top: t,
+          bottom: b,
+        ),
+        child: this,
+      );
 }
 
 /// Other values


### PR DESCRIPTION
I've already update all Padding widget to widget extension, I create 2 custom extension for padding symetric and all custom (padding only and padding fromLRTB) and also found inconsistency in the naming of padding

### 1. Extension custom padding symetric 
#### Code
```dart
 /// Symetric Padding
  Padding sP(double horizontal, double vertical) => Padding(
    padding: EdgeInsets.symmetric(
      horizontal: horizontal,
      vertical: vertical,
    ),
    child: this,
  );
```

#### How to use
```dart
Text(
  'example',
  style: TextStyle(color: Colors.white),
).sP(10, 20), // Horizontal 10 and vertical 20
```

### 2. Extension for custom all padding
#### Code
```dart
 Padding cP({
    double t = 0.0,
    double b = 0.0,
    double l = 0.0,
    double r = 0.0,
  }) =>
      Padding(
        padding: EdgeInsets.only(
          left: l,
          right: r,
          top: t,
          bottom: b,
        ),
        child: this,
      );
```

#### How to use
```dart
Text(
  'example',
  style: TextStyle(color: Colors.white),
).cP(l: 8, t: 18, b: 8),
```

### Consistency
I also found an inconsistency in the naming of padding, to make the code more consistent I have fixed the extension and widgets that use it.

Example I found
- p8, but it says padding only top 8. Then I changed p8 to tP8

If you have any feedback, please let me know. Thank you 😆