### PR TITLE
fix(#188): Made child picture not mandatory when adding a new child

### DIFF
--- a/lib/app/pages/child_details_page.dart
+++ b/lib/app/pages/child_details_page.dart
@@ -95,12 +95,11 @@ class _ChildDetailsPageState extends State<ChildDetailsPage> {
           return [
             SliverAppBar(
               actions: [
-                if (model.image != null)
-                  ClipOval(
-                    child: Image.network(model.image!),
-                  ).p4
-                else
-                  const SizedBox.shrink(),
+                ClipOval(
+                  child: model.image != null
+                      ? Image.network(model.image!)
+                      : const Icon(Icons.person),
+                ).p4,
               ],
               elevation: 0.5,
               shadowColor: CustomColors.indigoLight,

--- a/lib/app/pages/edit_child_page.dart
+++ b/lib/app/pages/edit_child_page.dart
@@ -87,32 +87,33 @@ class _EditChildPageState extends State<EditChildPage> {
   Future<void> _submit(XFile? localFile) async {
     if (appState == AppState.loading) return;
     if (_validateAndSaveForm()) {
-      if (localFile == null) return;
       setState(() {
         appState = AppState.loading;
       });
 
       id = uuid.v4().substring(0, 8).toUpperCase();
-      try {
-        final fileExtension = path.extension(localFile.path);
-        JHLogger.$.d(fileExtension);
+      if(localFile!=null) {
+        try {
+          final fileExtension = path.extension(localFile.path);
+          JHLogger.$.d(fileExtension);
 
-        final firebaseStorageRef = FirebaseStorage.instance
-            .ref()
-            .child('Child/"$id"/$id$fileExtension');
+          final firebaseStorageRef = FirebaseStorage.instance
+              .ref()
+              .child('Child/"$id"/$id$fileExtension');
 
-        await firebaseStorageRef
-            .putFile(File(localFile.path))
-            .catchError((Function onError) {
-          JHLogger.$.e(onError);
-          // ignore: return_of_invalid_type_from_catch_error
-          return false;
-        });
-        final url = await firebaseStorageRef.getDownloadURL();
-        _imageURL = url;
-        JHLogger.$.d('download url: $url');
-      } catch (e) {
-        JHLogger.$.d('...skipping image upload');
+          await firebaseStorageRef
+              .putFile(File(localFile.path))
+              .catchError((Function onError) {
+            JHLogger.$.e(onError);
+            // ignore: return_of_invalid_type_from_catch_error
+            return false;
+          });
+          final url = await firebaseStorageRef.getDownloadURL();
+          _imageURL = url;
+          JHLogger.$.d('download url: $url');
+        } catch (e) {
+          JHLogger.$.d('...skipping image upload');
+        }
       }
 
       try {


### PR DESCRIPTION
Fixes JordyHers-org/Times-up-flutter#188:

Made child picture not mandatory when adding a new child. A default icon will be displayed as a substitute.

![image](https://github.com/JordyHers-org/Times-up-flutter/assets/5429312/6c9d568f-016a-4e03-bc99-a10e54f73697)
![image](https://github.com/JordyHers-org/Times-up-flutter/assets/5429312/081ef0f6-e02d-4d84-b7c6-6759e5e34341)
![image](https://github.com/JordyHers-org/Times-up-flutter/assets/5429312/da512c99-efb5-49d3-a307-2c1c08366e85)
